### PR TITLE
community/ghc: build with lower verbosity level and -j $JOBS

### DIFF
--- a/community/ghc/APKBUILD
+++ b/community/ghc/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=ghc
 pkgver=8.6.5
 _llvmver=9
-pkgrel=3
+pkgrel=4
 # Normal non rc candidate
 _urlprefix="$pkgver"
 _pkgprefix="$pkgname-$pkgver"
@@ -121,12 +121,12 @@ build() {
 	sed -i -e 's/unknown-linux-gnueabi/alpine-linux/g' llvm-targets
 	sed -i -e 's/unknown-linux-gnu/alpine-linux/g' llvm-targets
 
-	make
+	make V=0 -j$JOBS
 }
 
 check() {
 	cd "$builddir/testsuite"
-	make fast THREADS=$JOBS
+	make fast THREADS=$JOBS VERBOSE=1
 }
 
 doc() {


### PR DESCRIPTION
Let's see if it's enough to avoid Travis CI error.

* `V=0` will display only the compiled file, not the command line (same number of lines, but much shorter)
* `VERBOSE=1` for tests should display only errors (default is 3, see https://gitlab.haskell.org/ghc/ghc/wikis/building/running-tests/settings)

Those are sane defaults which won't hide errors.

I also added the `-j$JOBS` that seemed to be missing for the build, hopefully it was not avoided  because of a problem.